### PR TITLE
Add piece queue, animation and space rotation

### DIFF
--- a/src/PuyoGame.css
+++ b/src/PuyoGame.css
@@ -19,3 +19,24 @@
 .cell.green { background: #66cc66; }
 .cell.blue { background: #6699ff; }
 .cell.yellow { background: #ffee66; }
+
+.next-pieces {
+  display: flex;
+  justify-content: center;
+  margin: 10px 0;
+}
+
+.next-piece .cell {
+  width: 20px;
+  height: 20px;
+}
+
+@keyframes fadeOut {
+  to {
+    opacity: 0;
+  }
+}
+
+.cell.clearing {
+  animation: fadeOut 0.3s forwards;
+}


### PR DESCRIPTION
## Summary
- support next two pieces
- animate puyos disappearing
- drop blocks individually after placement
- rotate with the space bar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ecda8c3e083308ae875477b2eddb3